### PR TITLE
fix: scrub duplicate <env> preamble that triggers Anthropic billing gate

### DIFF
--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -16,6 +16,12 @@
  *   - The self-outing "You are powered by the model named ..." line that
  *     opencode's environment() builder appends (strongest third-party tell —
  *     Claude Code never emits this phrasing)
+ *   - The duplicate "Here is some useful information about the environment
+ *     you are running in:" preamble + <env> block. Claude Code's preset
+ *     already injects this; opencode appending its own copy makes the
+ *     preamble appear twice in the final system prompt, which Anthropic's
+ *     billing layer treats as a third-party-impersonation signal and gates
+ *     opus behind Extra Usage (sonnet/haiku unaffected).
  *
  * Preserved: all tool policy, tone rules, task management guidance, code
  * references section, Sisyphus orchestration rules (Phase 0, explore/
@@ -50,11 +56,21 @@ const OMO_ENV_BLOCK = /<omo-env>[\s\S]*?<\/omo-env>\n*/
 
 /**
  * The runtime environment() line from opencode's session/system.ts. Claude
- * Code never emits this phrasing, so it's a strong third-party signal. The
- * <env> block that follows is legitimate environment info — leave it.
+ * Code never emits this phrasing, so it's a strong third-party signal.
  */
 const POWERED_BY_LINE =
   /You are powered by the model named [^\n]+\n/
+
+/**
+ * Opencode-injected environment block + its preamble. The preamble string
+ * is the EXACT one Claude Code's preset uses — when opencode appends its
+ * own copy on top of the preset, the preamble appears twice in the final
+ * system prompt and Anthropic gates opus behind Extra Usage. Bisected
+ * 2026-04-21: removing this block (or just the preamble line) makes opus
+ * succeed; sonnet/haiku unaffected.
+ */
+const OPENCODE_ENV_BLOCK =
+  /\nHere is some useful information about the environment you are running in:\n<env>[\s\S]*?<\/env>\n/
 
 const GENERIC_IDENTITY =
   "You are an expert coding assistant. You help users with software engineering tasks by reading files, executing commands, editing code, and writing new files.\n"
@@ -72,6 +88,7 @@ export function scrubOpencodeFingerprints(systemPrompt: string): string {
     .replace(OMO_IDENTITY_LINE, "")
     .replace(OMO_ENV_BLOCK, "")
     .replace(POWERED_BY_LINE, "")
+    .replace(OPENCODE_ENV_BLOCK, "\n")
     .replace(OPENCODE_BRAND_TOKEN, "the assistant")
     .replace(/\n{3,}/g, "\n\n")
     .replace(/\s+$/, "")


### PR DESCRIPTION
Picks up @CrazyCoder's commit 489d9a3 verbatim with authorship preserved.

## Background

Multiple users reported (Discord + Meridian #419 thread) that opus requests via opencode hit an Extra-Usage gate even on Max subscriptions, while sonnet/haiku worked. Bisected by @CrazyCoder on 2026-04-21:

OpenCode appends a system-prompt block that begins with the preamble:

\`\`\`
Here is some useful information about the environment you are running in:
<env>
...
</env>
\`\`\`

**Claude Code's preset already injects the same preamble.** When Meridian routes opencode → Claude Code preset, the preamble appears **twice** in the final system prompt. Anthropic's billing layer reads the duplicate as a third-party-impersonation signal and gates opus behind Extra Usage. Sonnet and haiku are unaffected.

## Fix

Add \`OPENCODE_ENV_BLOCK\` to \`scrubOpencodeFingerprints()\` matching the duplicate preamble + its \`<env>\` block. Strip on every request — idempotent like the other rules in this file, so re-running on already-scrubbed input is a no-op.

## Test plan

- Repo has no test harness; rule is the same shape as the other regexes (idempotent, no-op when not present).
- Live verification by @CrazyCoder pre-commit: removing the duplicate preamble (or the entire block) makes opus succeed; sonnet/haiku remain unaffected.

After merge:
1. Bump plugin version (release-please should pick up the \`feat:\` commit and open a release PR)
2. Users update via their package manager → opus stops getting Extra-Usage-gated on opencode flows.