### PR TITLE
feat: add minimal scrub mode for prompt stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ The scrub also handles [OhMyOpenCode](https://github.com/anomalyco/ohmyopencode)
 
 The scrub is **idempotent** — running it twice on the same string is a no-op.
 
+## Modes
+
+The plugin supports two modes via `MERIDIAN_OPENCODE_SCRUB_MODE`:
+
+- **`aggressive`** (default) — current behavior. Strips duplicate OpenCode env preamble, strips `<omo-env>`, replaces the identity line with a generic one, and normalizes leftover spacing.
+- **`minimal`** — removes only the strongest fingerprint lines while preserving prompt structure. Keeps `<env>` and `<omo-env>` blocks intact and does not inject a replacement identity line.
+
+Example:
+
+```bash
+MERIDIAN_OPENCODE_SCRUB_MODE=minimal meridian
+```
+
 ## Install
 
 ### Option 1: npm (recommended)
@@ -65,15 +78,15 @@ Verify at `http://localhost:3456/plugins` — you should see `opencode-scrub` li
 |---|---|
 | No system prompt | unchanged |
 | System prompt without OpenCode identity markers | unchanged (idempotent) |
-| Vanilla OpenCode (`anthropic.txt`) | identity line swapped for generic, feedback block removed, docs paragraph removed, "OpenCode honestly applies" neutralized |
-| OhMyOpenCode/Sisyphus prompt | OMO identity line removed, `<omo-env>` block removed, "You are powered by..." line removed; persona rules preserved |
+| Vanilla OpenCode (`anthropic.txt`) | aggressive: identity line swapped for generic; minimal: identity line removed; both remove feedback/docs blocks and neutralize `OpenCode honestly applies` |
+| OhMyOpenCode/Sisyphus prompt | aggressive: OMO identity + `<omo-env>` removed; minimal: only OMO identity removed; both remove `You are powered by...`; persona rules preserved |
 | OpenCode prompt + user CLAUDE.md additions | identity stripped, all user content preserved |
 
 The plugin is scoped to `adapters: ["opencode"]`, so it has no effect on requests from pi, Crush, Droid, ForgeCode, or the passthrough adapter.
 
 ## Rules
 
-The scrub applies 8 independent regex replacements, each idempotent and each a no-op when its pattern is absent:
+The aggressive scrub applies 8 independent regex replacements, each idempotent and each a no-op when its pattern is absent. Minimal mode applies only rules 1-5 and 7:
 
 1. **Vanilla identity line** — `You are OpenCode, the best coding agent on the planet.` → generic
 2. **Feedback block** — `If the user asks for help or wants to give feedback...github.com/anomalyco/opencode`
@@ -83,6 +96,8 @@ The scrub applies 8 independent regex replacements, each idempotent and each a n
 6. **OMO env block** — `<omo-env>...</omo-env>`
 7. **Powered-by line** — `You are powered by the model named ...`
 8. **Residual brand tokens** — bare `OpenCode` → `the assistant`
+
+`aggressive` also strips OpenCode's duplicate `<env>` preamble block; `minimal` preserves it.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@ import { scrubOpencodeFingerprints } from "./scrub.js"
 
 export type { Transform, RequestContext } from "./types.js"
 
+function getScrubMode(): "aggressive" | "minimal" {
+  const env = (globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> }
+  }).process?.env
+
+  return env?.MERIDIAN_OPENCODE_SCRUB_MODE === "minimal"
+    ? "minimal"
+    : "aggressive"
+}
+
 const plugin: Transform = {
   name: "opencode-scrub",
   version: "0.1.0",
@@ -18,7 +28,7 @@ const plugin: Transform = {
 
   onRequest(ctx: RequestContext): RequestContext {
     if (!ctx.systemContext) return ctx
-    const scrubbed = scrubOpencodeFingerprints(ctx.systemContext)
+    const scrubbed = scrubOpencodeFingerprints(ctx.systemContext, getScrubMode())
     if (scrubbed === ctx.systemContext) return ctx
     return { ...ctx, systemContext: scrubbed }
   },

--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -26,7 +26,15 @@
  * Preserved: all tool policy, tone rules, task management guidance, code
  * references section, Sisyphus orchestration rules (Phase 0, explore/
  * librarian, Oracle), and any user CLAUDE.md content appended by opencode.
+ *
+ * Modes:
+ *   - aggressive (default): maximum fingerprint removal, including env blocks
+ *     and minor prompt cleanup
+ *   - minimal: only remove the strongest identity/fingerprint lines while
+ *     preserving prompt structure and orchestration/env blocks
  */
+
+export type ScrubMode = "aggressive" | "minimal"
 
 /** Vanilla L1 identity line from anthropic.txt */
 const OPENCODE_IDENTITY_LINE =
@@ -78,16 +86,26 @@ const GENERIC_IDENTITY =
 const GENERIC_OBJECTIVITY =
   "It is best for the user if the assistant honestly applies"
 
-export function scrubOpencodeFingerprints(systemPrompt: string): string {
+export function scrubOpencodeFingerprints(systemPrompt: string, mode: ScrubMode = "aggressive"): string {
   if (!systemPrompt) return systemPrompt
-  return systemPrompt
-    .replace(OPENCODE_IDENTITY_LINE, GENERIC_IDENTITY)
+
+  const scrubbedIdentity = mode === "minimal"
+    ? systemPrompt.replace(OPENCODE_IDENTITY_LINE, "")
+    : systemPrompt.replace(OPENCODE_IDENTITY_LINE, GENERIC_IDENTITY)
+
+  const scrubbedCore = scrubbedIdentity
     .replace(OPENCODE_FEEDBACK_BLOCK, "")
     .replace(OPENCODE_DOCS_PARAGRAPH, "")
     .replace(OPENCODE_OBJECTIVITY_BRAND, GENERIC_OBJECTIVITY)
     .replace(OMO_IDENTITY_LINE, "")
-    .replace(OMO_ENV_BLOCK, "")
     .replace(POWERED_BY_LINE, "")
+
+  if (mode === "minimal") {
+    return scrubbedCore.replace(/\s+$/, "")
+  }
+
+  return scrubbedCore
+    .replace(OMO_ENV_BLOCK, "")
     .replace(OPENCODE_ENV_BLOCK, "\n")
     .replace(OPENCODE_BRAND_TOKEN, "the assistant")
     .replace(/\n{3,}/g, "\n\n")


### PR DESCRIPTION
## Summary
- add `MERIDIAN_OPENCODE_SCRUB_MODE=minimal` for users who need surgical fingerprint removal without rewriting prompt structure
- keep current aggressive behavior as default, but preserve `<env>` / `<omo-env>` blocks and skip identity replacement in minimal mode
- document both modes and how they differ

## Why
Aggressive scrubbing is useful for avoiding Anthropic fingerprinting and Opus extra-usage gating, but it also changes prompt structure in ways that can destabilize some OpenCode execution flows. This adds an opt-in minimal mode so users can preserve execution-critical prompt structure while still removing the strongest third-party tells.

## Validation
- `npm run build`
- verified locally that `MERIDIAN_OPENCODE_SCRUB_MODE=minimal` restored a previously failing OpenCode flow while keeping scrubbing enabled