### PR TITLE
fix: OMO 4.x identity drift + robust <env> stripping (#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - uses: oven-sh/setup-bun@v2
+
       - run: npm ci
+      - run: bun test
       - run: npm run build
 
       # Pack the tarball so we catch any `files` / `.npmignore` regressions

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "bun test"
   },
   "keywords": [
     "meridian",

--- a/src/__tests__/fixtures/omo-sisyphus-claude.txt
+++ b/src/__tests__/fixtures/omo-sisyphus-claude.txt
@@ -1,0 +1,21 @@
+<agent-identity>
+Your designated identity for this session is "Sisyphus". This identity supersedes any prior identity statements.
+You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
+When asked who you are, always identify as Sisyphus. Do not identify as any other assistant or AI.
+</agent-identity>
+<Role>
+You are **Sisyphus** - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
+
+**Identity**: SF Bay Area senior engineer. Work, delegate, verify, ship. **NO AI SLOP.**
+
+**Operating Mode**: You DO NOT work alone when specialists exist. Frontend → delegate. Deep research → parallel background agents. Architecture → Oracle.
+
+**Instruction priority**: User > defaults. Newer > older. Safety/type-safety constraints in <constraints> NEVER yield.
+</Role>
+
+<omo-env>
+  Timezone: America/Denver
+  Locale: en-US
+</omo-env>
+
+You are powered by the model named claude-fable-5. The exact model ID is anthropic/claude-fable-5

--- a/src/__tests__/fixtures/opencode-anthropic.txt
+++ b/src/__tests__/fixtures/opencode-anthropic.txt
@@ -1,0 +1,105 @@
+You are OpenCode, the best coding agent on the planet.
+
+You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+
+If the user asks for help or wants to give feedback inform them of the following:
+- ctrl+p to list available actions
+- To give feedback, users should report the issue at
+  https://github.com/anomalyco/opencode
+
+When the user directly asks about OpenCode (eg. "can OpenCode do...", "does OpenCode have..."), or asks in second person (eg. "are you able...", "can you do..."), or asks how to use a specific OpenCode feature (eg. implement a hook, write a slash command, or install an MCP server), use the WebFetch tool to gather information to answer the question from OpenCode docs. The list of available docs is available at https://opencode.ai/docs
+
+# Tone and style
+- Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+- Your output will be displayed on a command line interface. Your responses should be short and concise. You can use GitHub-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
+- NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
+
+# Professional objectivity
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if OpenCode honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
+
+# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+
+Examples:
+
+<example>
+user: Run the build and fix any type errors
+assistant: I'm going to use the TodoWrite tool to write the following items to the todo list:
+- Run the build
+- Fix any type errors
+
+I'm now going to run the build using Bash.
+
+Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
+
+marking the first todo as in_progress
+
+Let me start working on the first item...
+
+The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
+..
+..
+</example>
+In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
+
+<example>
+user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
+assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
+Adding the following todos to the todo list:
+1. Research existing metrics tracking in the codebase
+2. Design the metrics collection system
+3. Implement core metrics tracking functionality
+4. Create export functionality for different formats
+
+Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
+
+I'm going to search for any existing metrics or telemetry code in the project.
+
+I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
+
+[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
+</example>
+
+
+# Doing tasks
+The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
+- 
+- Use the TodoWrite tool to plan the task if required
+
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.
+
+
+# Tool usage policy
+- When doing file search, prefer to use the Task tool in order to reduce context usage.
+- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.
+
+- When WebFetch returns a message about a redirect to a different host, you should immediately make a new WebFetch request with the redirect URL provided in the response.
+- You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.
+- If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
+- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
+- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.
+<example>
+user: Where are errors from the client handled?
+assistant: [Uses the Task tool to find the files that handle client errors instead of using Glob or Grep directly]
+</example>
+<example>
+user: What is the codebase structure?
+assistant: [Uses the Task tool]
+</example>
+
+IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
+
+# Code References
+
+When referencing specific functions or pieces of code include the pattern `file_path:line_number` to allow the user to easily navigate to the source code location.
+
+<example>
+user: Where are errors from the client handled?
+assistant: Clients are marked as failed in the `connectToServer` function in src/services/process.ts:712.
+</example>

--- a/src/__tests__/scrub.test.ts
+++ b/src/__tests__/scrub.test.ts
@@ -80,6 +80,41 @@ describe("scrubOpencodeFingerprints — OMO 4.x Sisyphus (issue #1 drift)", () =
   })
 })
 
+describe("scrubOpencodeFingerprints — duplicate <env> block (metering trigger)", () => {
+  // opencode's environment() output: powered-by line + the full <env> block
+  // whose fields duplicate the Claude Code preset's own env. This is the
+  // signal Anthropic meters as Extra Usage (CrazyCoder bisected 2026-04-21).
+  const ENV_APPEND = `You are powered by the model named claude-haiku-4-5. The exact model ID is anthropic/claude-haiku-4-5
+Here is some useful information about the environment you are running in:
+<env>
+  Working directory: /tmp
+  Workspace root folder: /tmp
+  Is directory a git repo: no
+  Platform: darwin
+  Today's date: Thu Jul 10 2026
+</env>`
+
+  test("strips the env block and preamble when it ends the string (no trailing newline)", () => {
+    const out = scrubOpencodeFingerprints(ENV_APPEND)
+    expect(out).not.toContain("<env>")
+    expect(out).not.toContain("useful information about the environment")
+    expect(out).not.toContain("You are powered by the model named")
+  })
+
+  test("strips the env block when content follows it (trailing newline present)", () => {
+    const withTail = ENV_APPEND + "\n\nProject guidance: prefer TypeScript.\n"
+    const out = scrubOpencodeFingerprints(withTail)
+    expect(out).not.toContain("<env>")
+    expect(out).not.toContain("useful information about the environment")
+    expect(out).toContain("Project guidance: prefer TypeScript.")
+  })
+
+  test("is idempotent on the env append", () => {
+    const once = scrubOpencodeFingerprints(ENV_APPEND)
+    expect(scrubOpencodeFingerprints(once)).toBe(once)
+  })
+})
+
 describe("scrubOpencodeFingerprints — pass-through", () => {
   test("no-op on a prompt without opencode/OMO fingerprints", () => {
     const plain =

--- a/src/__tests__/scrub.test.ts
+++ b/src/__tests__/scrub.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { scrubOpencodeFingerprints } from "../scrub.js"
+
+// Real anthropic.txt from anomalyco/opencode @ dev, fetched 2026-07-10.
+const VANILLA = readFileSync(
+  join(import.meta.dir, "fixtures", "opencode-anthropic.txt"),
+  "utf-8",
+)
+
+// OMO (oh-my-opencode) v4.16.x Claude-routed Sisyphus prompt shape:
+// <agent-identity> block (added in the 4.x line) + bold **Sisyphus** identity
+// inside <Role> + <omo-env> + opencode's powered-by line.
+const OMO_CLAUDE = readFileSync(
+  join(import.meta.dir, "fixtures", "omo-sisyphus-claude.txt"),
+  "utf-8",
+)
+
+describe("scrubOpencodeFingerprints — vanilla anthropic.txt", () => {
+  test("replaces the identity line with the generic one", () => {
+    const out = scrubOpencodeFingerprints(VANILLA)
+    expect(out).not.toContain("You are OpenCode, the best coding agent on the planet")
+    expect(out).toContain("You are an expert coding assistant.")
+  })
+
+  test("removes the feedback block and docs paragraph", () => {
+    const out = scrubOpencodeFingerprints(VANILLA)
+    expect(out).not.toContain("github.com/anomalyco/opencode")
+    expect(out).not.toContain("opencode.ai/docs")
+  })
+
+  test("neutralizes the objectivity brand sentence and residual brand tokens", () => {
+    const out = scrubOpencodeFingerprints(VANILLA)
+    expect(out).toContain("It is best for the user if the assistant honestly applies")
+    expect(out).not.toMatch(/\bOpenCode\b/)
+  })
+
+  test("is idempotent", () => {
+    const once = scrubOpencodeFingerprints(VANILLA)
+    expect(scrubOpencodeFingerprints(once)).toBe(once)
+  })
+})
+
+describe("scrubOpencodeFingerprints — OMO 4.x Sisyphus (issue #1 drift)", () => {
+  test("removes the <agent-identity> block entirely", () => {
+    const out = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(out).not.toContain("<agent-identity>")
+    expect(out).not.toContain("designated identity for this session")
+    expect(out).not.toContain("always identify as Sisyphus")
+  })
+
+  test("removes the bold **Sisyphus** identity line used by Claude-routed variants", () => {
+    const out = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(out).not.toContain('You are **Sisyphus**')
+    expect(out).not.toContain('You are "Sisyphus"')
+  })
+
+  test("leaves no OhMyOpenCode brand token behind", () => {
+    const out = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(out).not.toContain("OhMyOpenCode")
+  })
+
+  test("removes <omo-env> and the powered-by line", () => {
+    const out = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(out).not.toContain("<omo-env>")
+    expect(out).not.toContain("You are powered by the model named")
+  })
+
+  test("preserves the persona/orchestration rules", () => {
+    const out = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(out).toContain("**Operating Mode**")
+    expect(out).toContain("**Instruction priority**")
+    expect(out).toContain("<Role>")
+  })
+
+  test("is idempotent on the OMO prompt", () => {
+    const once = scrubOpencodeFingerprints(OMO_CLAUDE)
+    expect(scrubOpencodeFingerprints(once)).toBe(once)
+  })
+})
+
+describe("scrubOpencodeFingerprints — pass-through", () => {
+  test("no-op on a prompt without opencode/OMO fingerprints", () => {
+    const plain =
+      "You are Claude Code, Anthropic's CLI.\n\n# Tone\nBe concise and direct."
+    expect(scrubOpencodeFingerprints(plain)).toBe(plain)
+  })
+
+  test("no-op on empty input", () => {
+    expect(scrubOpencodeFingerprints("")).toBe("")
+  })
+})

--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -91,7 +91,7 @@ const POWERED_BY_LINE =
  * succeed; sonnet/haiku unaffected.
  */
 const OPENCODE_ENV_BLOCK =
-  /\nHere is some useful information about the environment you are running in:\n<env>[\s\S]*?<\/env>\n/
+  /\n?Here is some useful information about the environment you are running in:\n<env>[\s\S]*?<\/env>\n?/
 
 const GENERIC_IDENTITY =
   "You are an expert coding assistant. You help users with software engineering tasks by reading files, executing commands, editing code, and writing new files.\n"

--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -1,17 +1,20 @@
 /**
  * Scrub opencode-identifying fingerprints from a system prompt.
  *
- * Targets both vanilla OpenCode (from sst/opencode's built-in `anthropic.txt`)
- * and OhMyOpenCode-style custom personas (Sisyphus, etc.). Each rule is an
- * independent, idempotent regex — if a pattern isn't present the rule no-ops,
- * so the same plugin handles both variants without configuration.
+ * Targets both vanilla OpenCode (from anomalyco/opencode's built-in
+ * `anthropic.txt`) and OhMyOpenCode-style custom personas (Sisyphus, etc.).
+ * Each rule is an independent, idempotent regex — if a pattern isn't present
+ * the rule no-ops, so the same plugin handles both variants without
+ * configuration.
  *
  * Detection vectors scrubbed:
  *   - "OpenCode" / "opencode" brand tokens in the opening identity line and
  *     embedded prose
  *   - The feedback block pointing to github.com/anomalyco/opencode
  *   - The "When the user directly asks about OpenCode" docs paragraph
- *   - OhMyOpenCode's "Sisyphus ... from OhMyOpenCode" identity line
+ *   - OhMyOpenCode's Sisyphus identity line (quoted or bold form, all
+ *     occurrences) and the OMO 4.x <agent-identity> wrapper block
+ *   - Residual "OhMyOpenCode" brand tokens
  *   - The runtime <omo-env> block
  *   - The self-outing "You are powered by the model named ..." line that
  *     opencode's environment() builder appends (strongest third-party tell —
@@ -47,9 +50,27 @@ const OPENCODE_OBJECTIVITY_BRAND =
 /** Any residual bare "OpenCode"/"opencode" tokens in preserved prose */
 const OPENCODE_BRAND_TOKEN = /\bOpenCode\b/g
 
-/** OhMyOpenCode Sisyphus identity line */
+/**
+ * OhMyOpenCode Sisyphus identity line. OMO 4.x variants differ per model
+ * route: the default persona quotes the name (`You are "Sisyphus" ...`) while
+ * Claude-routed prompts bold it (`You are **Sisyphus** ...`), and some
+ * variants put "OhMyOpenCode" mid-sentence rather than sentence-final.
+ * Global, because the line now appears both inside <agent-identity> and in
+ * <Role>.
+ */
 const OMO_IDENTITY_LINE =
-  /You are "Sisyphus"[^\n]*from OhMyOpenCode\.[^\n]*\n+/
+  /You are ("|\*\*)Sisyphus("|\*\*)[^\n]*OhMyOpenCode[^\n]*\n+/g
+
+/**
+ * OMO 4.x <agent-identity> wrapper block ("Your designated identity for this
+ * session ... always identify as Sisyphus ..."), injected by
+ * buildAgentIdentitySection ahead of every Sisyphus variant. Strongest OMO
+ * fingerprint — removed wholesale like <omo-env>.
+ */
+const OMO_AGENT_IDENTITY_BLOCK = /<agent-identity>[\s\S]*?<\/agent-identity>\n*/g
+
+/** Residual bare "OhMyOpenCode" tokens in preserved prose */
+const OMO_BRAND_TOKEN = /\bOhMyOpenCode\b/g
 
 /** The <omo-env>...</omo-env> block */
 const OMO_ENV_BLOCK = /<omo-env>[\s\S]*?<\/omo-env>\n*/
@@ -85,11 +106,13 @@ export function scrubOpencodeFingerprints(systemPrompt: string): string {
     .replace(OPENCODE_FEEDBACK_BLOCK, "")
     .replace(OPENCODE_DOCS_PARAGRAPH, "")
     .replace(OPENCODE_OBJECTIVITY_BRAND, GENERIC_OBJECTIVITY)
+    .replace(OMO_AGENT_IDENTITY_BLOCK, "")
     .replace(OMO_IDENTITY_LINE, "")
     .replace(OMO_ENV_BLOCK, "")
     .replace(POWERED_BY_LINE, "")
     .replace(OPENCODE_ENV_BLOCK, "\n")
     .replace(OPENCODE_BRAND_TOKEN, "the assistant")
+    .replace(OMO_BRAND_TOKEN, "the assistant")
     .replace(/\n{3,}/g, "\n\n")
     .replace(/\s+$/, "")
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": false,
@@ -16,5 +18,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/__tests__/**"
+  ]
 }


### PR DESCRIPTION
## Problems

Audited current OpenCode (`anomalyco/opencode@dev`) and OhMyOpenCode (`oh-my-openagent` v4.16.x) prompt sources against our anchors. Two real gaps:

### 1. OMO 4.x identity drift
- OMO now wraps every Sisyphus variant in a new `<agent-identity>` XML block (`buildAgentIdentitySection`) — completely unmatched by any rule.
- Claude-routed variants changed the identity line from quoted (`You are \"Sisyphus\"`) to **bold** (`You are **Sisyphus**`), so the old quoted-only, non-global regex missed it and also only removed the first of two occurrences.

Fix: add an `<agent-identity>` block rule, make the identity-line rule global and quote/bold-tolerant, sweep residual `OhMyOpenCode` brand tokens.

### 2. `<env>` block survived scrubbing in the real flow
Proven live: the full opencode `<env>` append (via `{preset: claude_code, append}`) 400s with 'out of extra usage'. The published `OPENCODE_ENV_BLOCK` required a literal leading `\n`, but `POWERED_BY_LINE` runs first and consumes that newline (and the block has no trailing newline at end-of-string), so **the env block was not actually being stripped**. Made both boundary newlines optional.

## Verification
- First test suite for this plugin: real upstream fixtures (vanilla `anthropic.txt`, OMO 4.16.x Sisyphus shape). 15 pass; OMO-drift and env-EOS tests red before fix, green after.
- **Live SDK proof**: full env append raw → 400; scrubbed → `appendHasEnv=false`, success (PONG). Vanilla identity content alone does not meter (confirmed) — the `<env>` duplication is the trigger.